### PR TITLE
Fix for AttributeError: 'ImportTask' object has no attribute 'item'

### DIFF
--- a/beetsplug/drop2beets.py
+++ b/beetsplug/drop2beets.py
@@ -109,6 +109,9 @@ class Drop2BeetsPlugin(BeetsPlugin):
         self.attributes = None
 
     def on_import_task_created(self, task, session):
+        # Some ImportTasks, like progress updates, have no item; ignore them
+        if not hasattr(task, 'item'):
+            return [task]
         path = str(task.item.path, 'utf-8', 'ignore')
         folder = os.path.dirname(path)
         dropbox_path = folder[len(self.dropbox_path):]


### PR DESCRIPTION
Fix for #4 

Some tasks, well, don't have an item! see the beets `SentinelImportTask` for more context. This may occur when the beets import/group_albums setting is enabled.